### PR TITLE
Fix error for nested paths on file write

### DIFF
--- a/lib/backend/post_wildcard.js
+++ b/lib/backend/post_wildcard.js
@@ -7,22 +7,22 @@ module.exports.register = (app, options) => {
     const dataDir = options['data-dir'];
 
     app.post(['/', '/*'], (request, response) => {
-        const path = join(dataDir, request.path);
+        const lastIndexOf = request.path.lastIndexOf('/');
+        const requestPath = request.path.substring(0, lastIndexOf);
+        const directory = join(dataDir, requestPath);
+        const fileName = request.path.substring(lastIndexOf + 1);
+        const filePath = directory.concat('/').concat(fileName);
 
-        if (fs.existsSync(path)) {
-            if (fs.statSync(path).isDirectory()) {
-                response.status(409);
-                return response.end();
-            }
-
-            fs.truncateSync(path)
+        if (fs.existsSync(filePath)) {
+            response.status(409);
+            return response.end();
         }
 
-        if (!fs.existsSync(dirname(path))) {
-            fs.mkdirSync(path, {recursive: true});
+        if (!fs.existsSync(directory)) {
+            fs.mkdirSync(directory, {recursive: true});
         }
 
-        request.pipe(fs.createWriteStream(path));
+        request.pipe(fs.createWriteStream(filePath));
 
         response.status(201);
         return response.end();


### PR DESCRIPTION
Fixed error in post_wildcard.js where filename was interpreted as a directory for nested paths

e.g. "POST /backend/foo" -> "GET /backend/foo" working now